### PR TITLE
Merge timeout for realtime parsing timeout setting

### DIFF
--- a/firstrun.py
+++ b/firstrun.py
@@ -431,6 +431,10 @@ class settings_importer(object):
         except ConfigParser.NoOptionError:
             self.event_colors = settings.defaults.event_colors
         try:
+            self.event_scheme = self.conf.get("gui", "event_scheme")
+        except ConfigParser.NoOptionError:
+            self.event_scheme = settings.defaults.event_scheme
+        try:
             self.logo_color = self.conf.get("gui", "logo_color")
         except ConfigParser.NoOptionError:
             self.logo_color = settings.defaults.logo_color

--- a/settings.py
+++ b/settings.py
@@ -39,16 +39,29 @@ class defaults:
     size = "big"
     # Set the corner the overlay will be displayed in
     pos = "TR"
+    # Set the text color of the parser
     color = "#236ab2"
+    # Set the logo color
     logo_color = "green"
+    # Overlay background color
     overlay_bg_color = "white"
+    # Overlay color that is displayed as transparent
     overlay_tr_color = "white"
+    # Overlay text color
     overlay_tx_color = "yellow"
+    # Overlay text font
     overlay_tx_font = "Calibri"
+    # Overlay text size
     overlay_tx_size = "12"
+    # Only display overlay when a GSF match is running
     overlay_when_gsf = str(False)
+    # Set the timeout for reading from file for realtime
+    timeout = 0.1
+    # Event color options
     event_colors = "basic"
+    # Event color scheme
     event_scheme = "default"
+    # The date format for in the files Listbox
     date_format = "ymd"
 
 
@@ -102,6 +115,7 @@ class settings:
         self.opacity = float(self.conf.get("realtime", "opacity"))
         self.size = self.conf.get("realtime", "size")
         self.pos = self.conf.get("realtime", "pos")
+        self.timeout = float(self.conf.get("realtime", "timeout"))
         self.color = self.conf.get("gui", "color")
         self.event_colors = self.conf.get("gui", "event_colors")
         self.event_scheme = self.conf.get("gui", "event_scheme")
@@ -156,6 +170,7 @@ class settings:
         self.conf.set("realtime", "overlay_tx_font", defaults.overlay_tx_font)
         self.conf.set("realtime", "overlay_tx_size", defaults.overlay_tx_size)
         self.conf.set("realtime", "overlay_when_gsf", defaults.overlay_when_gsf)
+        self.conf.set("realtime", "timeout", defaults.timeout)
         with open(self.file_name, "w") as settings_file_object:
             self.conf.write(settings_file_object)
         print "[DEBUG] Defaults written"
@@ -190,6 +205,7 @@ class settings:
                   tx_font=defaults.overlay_tx_font,
                   tx_size=defaults.overlay_tx_size,
                   overlay_when_gsf=defaults.overlay_when_gsf,
+                  timeout=defaults.timeout,
                   event_colors=defaults.event_colors,
                   event_scheme=defaults.event_scheme,
                   date_format=defaults.date_format):
@@ -228,6 +244,7 @@ class settings:
         self.conf.set("realtime", "overlay_tx_font", tx_font)
         self.conf.set("realtime", "overlay_tx_size", tx_size)
         self.conf.set("realtime", "overlay_when_gsf", overlay_when_gsf)
+        self.conf.set("realtime", "timeout", timeout)
         self.conf.set("gui", "color", color)
         self.conf.set("gui", "logo_color", logo_color)
         self.conf.set("gui", "event_colors", event_colors)

--- a/settingsframe.py
+++ b/settingsframe.py
@@ -181,11 +181,13 @@ class settings_frame(ttk.Frame):
                                                      text="Yes", value=True)
         self.overlay_when_gsf_false = ttk.Radiobutton(self.realtime_frame, variable=self.overlay_when_gsf,
                                                       text="No", value=False)
-        self.realtime_timeout_label = tk.Label(self.realtime_frame, text="\tRealtime parsing timeout: ")
+        self.realtime_timeout_label = ttk.Label(self.realtime_frame, text="\tRealtime parsing timeout: ")
         self.realtime_timeout = tk.StringVar()
-        self.realtime_timeout_entry = ttk.Entry(self.realtime_frame, variable=self.realtime_timeout, width=4)
+        self.realtime_timeout_entry = ttk.Entry(self.realtime_frame, textvariable=self.realtime_timeout, width=10)
         self.realtime_timeout_help_button = ttk.Button(self.realtime_frame, text="Help",
-                                                       command=self.realtime_timeout_help_button)
+                                                       command=self.show_timeout_help)
+        self.realtime_timeout_help_label = ttk.Label(self.realtime_frame, text="Only change this if you are "
+                                                                               "experiencing performance issues!")
         ### MISC ###
         self.separator = ttk.Separator(self, orient=tk.HORIZONTAL)
         self.save_settings_button = ttk.Button(self.save_frame, text="  Save  ", command=self.save_settings)
@@ -207,8 +209,11 @@ class settings_frame(ttk.Frame):
     def show_timeout_help(self):
         tkMessageBox.showinfo("Help", "This is the setting for the sleep timeout for realtime parsing. "
                                       "Lowering this value will allow faster detection of change, but "
-                                      "it will also require more processing power and IO usage. Please "
-                                      "do not change this value if you do not know what that means.")
+                                      "it will also require more processing power and IO usage. Increasing "
+                                      "this value will reduce processing power requirements and IO usage. "
+                                      "Please do not change this value unless you are experiencing performance "
+                                      "issues that you can relate to the usage of the GSF Parser on a low-end "
+                                      "system.")
 
     def set_custom_event_colors(self):
         """
@@ -330,6 +335,8 @@ class settings_frame(ttk.Frame):
         self.realtime_timeout_label.grid(column=0, row=11, sticky=tk.W)
         self.realtime_timeout_entry.grid(column=1, row=11, sticky=tk.W)
         self.realtime_timeout_help_button.grid(column=2, row=11, sticky=tk.W)
+        self.realtime_timeout_help_label.grid(column=3, row=11, sticky=tk.W, columnspan=5,
+                                              padx=5)
         ### MISC ###
         self.save_settings_button.grid(column=0, row=1, padx=2)
         self.discard_settings_button.grid(column=1, row=1, padx=2)

--- a/settingsframe.py
+++ b/settingsframe.py
@@ -181,6 +181,11 @@ class settings_frame(ttk.Frame):
                                                      text="Yes", value=True)
         self.overlay_when_gsf_false = ttk.Radiobutton(self.realtime_frame, variable=self.overlay_when_gsf,
                                                       text="No", value=False)
+        self.realtime_timeout_label = tk.Label(self.realtime_frame, text="\tRealtime parsing timeout: ")
+        self.realtime_timeout = tk.StringVar()
+        self.realtime_timeout_entry = ttk.Entry(self.realtime_frame, variable=self.realtime_timeout, width=4)
+        self.realtime_timeout_help_button = ttk.Button(self.realtime_frame, text="Help",
+                                                       command=self.realtime_timeout_help_button)
         ### MISC ###
         self.separator = ttk.Separator(self, orient=tk.HORIZONTAL)
         self.save_settings_button = ttk.Button(self.save_frame, text="  Save  ", command=self.save_settings)
@@ -198,6 +203,12 @@ class settings_frame(ttk.Frame):
         self.thanks_label = ttk.Label(self.license_frame, text="Special thanks to Nightmaregale for bèta testing",
                                       justify=tk.LEFT)
         self.update_settings()
+
+    def show_timeout_help(self):
+        tkMessageBox.showinfo("Help", "This is the setting for the sleep timeout for realtime parsing. "
+                                      "Lowering this value will allow faster detection of change, but "
+                                      "it will also require more processing power and IO usage. Please "
+                                      "do not change this value if you do not know what that means.")
 
     def set_custom_event_colors(self):
         """
@@ -316,6 +327,9 @@ class settings_frame(ttk.Frame):
         self.overlay_when_gsf_label.grid(column=0, row=10)
         self.overlay_when_gsf_true.grid(column=1, row=10, sticky=tk.W)
         self.overlay_when_gsf_false.grid(column=2, row=10, sticky=tk.W)
+        self.realtime_timeout_label.grid(column=0, row=11, sticky=tk.W)
+        self.realtime_timeout_entry.grid(column=1, row=11, sticky=tk.W)
+        self.realtime_timeout_help_button.grid(column=2, row=11, sticky=tk.W)
         ### MISC ###
         self.save_settings_button.grid(column=0, row=1, padx=2)
         self.discard_settings_button.grid(column=1, row=1, padx=2)
@@ -366,6 +380,7 @@ class settings_frame(ttk.Frame):
         self.event_scheme.set(variables.settings_obj.event_scheme)
         variables.color_scheme.set_scheme(variables.settings_obj.event_scheme)
         self.date_format.set(variables.settings_obj.date_format)
+        self.realtime_timeout.set(variables.settings_obj.timeout)
 
     def save_settings(self):
         """
@@ -413,6 +428,7 @@ class settings_frame(ttk.Frame):
                                          tx_font=self.overlay_font.get(),
                                          tx_size=self.overlay_text_size_entry.get(),
                                          overlay_when_gsf=self.overlay_when_gsf.get(),
+                                         timeout=self.realtime_timeout.get(),
                                          event_colors=self.event_colors.get(),
                                          event_scheme=self.event_scheme.get(),
                                          date_format=self.date_format.get())

--- a/stalking_alt.py
+++ b/stalking_alt.py
@@ -85,7 +85,7 @@ class LogStalker(threading.Thread):
                 with open(self.current_file, "r") as file_obj:
                     self.read_so_far = len(file_obj.readlines())
             # sleep 0.1 seconds to reduce IO usage
-            time.sleep(0.1)
+            time.sleep(variables.settings_obj.timeout)
 
     def read_from_file(self):
         """


### PR DESCRIPTION
In timeout, I have implemented a setting for letting the user change the frequency with which the files in the CombatLogs folder are checked during realtime-parsing. This allows users on low-end systems to decrease the frequency in case they are experiencing performance issues such as long loading times due to the IO usage. I have not received any reports of this, but it is not difficult to imagine that users on a 5400RPM hard drive could be having trouble with the IO usage, as it is comparable to the average browser.