### PR TITLE
Merge folder into development for solution to #53

### DIFF
--- a/fileframe.py
+++ b/fileframe.py
@@ -13,6 +13,7 @@ except ImportError:
     import Tkinter as tk
 import ttk
 import tkMessageBox
+import tkFileDialog
 from PIL import Image, ImageTk
 # General imports
 import operator
@@ -223,9 +224,12 @@ class file_frame(ttk.Frame):
         try:
             os.chdir(variables.settings_obj.cl_path)
         except OSError:
-            tkMessageBox.showerror("Error", "Folder not valid: " + variables.settings_obj.cl_path)
-            self.splash.destroy()
-            return
+            tkMessageBox.showerror("Error", "The CombatLogs folder found in the settings file is not valid. Please "
+                                            "choose another folder.")
+            folder = tkFileDialog.askdirectory(title="CombatLogs folder")
+            variables.settings_obj.write_settings_dict({('parsing', 'cl_path'): folder})
+            variables.settings_obj.read_set()
+            os.chdir(variables.settings_obj.cl_path)
         for file in os.listdir(os.getcwd()):
             if file.endswith(".txt"):
                 if statistics.check_gsf(file):
@@ -274,10 +278,12 @@ class file_frame(ttk.Frame):
         try:
             os.chdir(variables.settings_obj.cl_path)
         except OSError:
-            tkMessageBox.showerror("Error", "Folder not valid: " + variables.settings_obj.cl_path)
-            if not silent:
-                self.splash.destroy()
-            return
+            tkMessageBox.showerror("Error", "The CombatLogs folder found in the settings file is not valid. Please "
+                                            "choose another folder.")
+            folder = tkFileDialog.askdirectory(title="CombatLogs folder")
+            variables.settings_obj.write_settings_dict({('parsing', 'cl_path'): folder})
+            variables.settings_obj.read_set()
+            os.chdir(variables.settings_obj.cl_path)
         for file in os.listdir(os.getcwd()):
             if file.endswith(".txt"):
                 if statistics.check_gsf(file):

--- a/gui.py
+++ b/gui.py
@@ -42,13 +42,13 @@ class main_window(tk.Tk):
         self.protocol("WM_DELETE_WINDOW", self.on_close)
         self.finished = False
         self.style = ttk.Style()
-        self.update_style(start=True)
         self.set_icon()
         variables.color_scheme.set_scheme(variables.settings_obj.event_scheme)
         # Get the screen properties
         variables.screen_w = self.winfo_screenwidth()
         variables.screen_h = self.winfo_screenheight()
         variables.path = variables.settings_obj.cl_path
+        self.update_style(start=True)
         # Get the default path for CombatLogs and the Installation path
         self.default_path = variables.settings_obj.cl_path
         # Set window properties and create a splash screen from the splash_screen class

--- a/settings.py
+++ b/settings.py
@@ -6,6 +6,7 @@
 
 # UI imports
 import tkMessageBox
+import tkFileDialog
 # General imports
 import os
 import ConfigParser
@@ -128,14 +129,6 @@ class settings:
         else:
             self.overlay_when_gsf = False
         print "[DEBUG] Settings read"
-        try:
-            os.chdir(self.cl_path)
-        except OSError:
-            tkMessageBox.showerror("Error", "An error occurred while changing "
-                                            "the directory to the specified "
-                                            "CombatLogs directory. Please "
-                                            "check if this folder exists: %s"
-                                   % self.cl_path)
 
     # Write the defaults settings found in the class defaults to a pickle in a
     # file
@@ -175,14 +168,6 @@ class settings:
             self.conf.write(settings_file_object)
         print "[DEBUG] Defaults written"
         self.read_set()
-        try:
-            os.chdir(self.cl_path)
-        except OSError:
-            tkMessageBox.showerror("Error", "An error occurred while changing "
-                                            "the directory to the specified "
-                                            "CombatLogs directory. Please "
-                                            "check if this folder exists: %s"
-                                   % self.cl_path)
 
     # Write the settings passed as arguments to a pickle in a file
     # Setting defaults to default if not specified, so all settings are always
@@ -254,14 +239,6 @@ class settings:
             self.conf.write(settings_file_object)
         self.read_set()
         print "[DEBUG] Settings written"
-        try:
-            os.chdir(self.cl_path)
-        except OSError:
-            tkMessageBox.showerror("Error", "An error occurred while changing "
-                                            "the directory to the specified "
-                                            "CombatLogs directory. Please "
-                                            "check if this folder exists: %s"
-                                   % self.cl_path)
 
     def write_settings_dict(self, settings_dict):
         """

--- a/settings.py
+++ b/settings.py
@@ -263,6 +263,20 @@ class settings:
                                             "check if this folder exists: %s"
                                    % self.cl_path)
 
+    def write_settings_dict(self, settings_dict):
+        """
+        :param settings_dict: Dictonary of settings with {cat_set_tuple: value} with
+                              cat_set_tuple as (section, setting)
+        :return: None
+        """
+        for cat_set_tuple, value in settings_dict.iteritems():
+            try:
+                self.conf.set(cat_set_tuple[0], cat_set_tuple[1], value)
+            except ConfigParser.NoSectionError:
+                tkMessageBox.showerror("Error", "This section does not exist: %s" % cat_set_tuple[0])
+        with open(self.file_name, "w") as settings_file_object:
+            self.conf.write(settings_file_object)
+
 
 class color_schemes:
     def __init__(self):

--- a/toplevels.py
+++ b/toplevels.py
@@ -39,8 +39,11 @@ class splash_screen(tk.Toplevel):
         try:
             list = os.listdir(variables.settings_obj.cl_path)
         except OSError:
-            tkMessageBox.showerror("Error", "The directory set in the settings cannot be accessed.")
-            return
+            tkMessageBox.showerror("Error", "The CombatLogs folder found in the settings file is not valid. Please "
+                                            "choose another folder.")
+            folder = tkFileDialog.askdirectory(title="CombatLogs folder")
+            variables.settings_obj.write_settings_dict({('parsing', 'cl_path'): folder})
+            os.chdir(variables.settings_obj.cl_path)
         except:
             print "[DEBUG] Running on UNIX, functionality disabled"
             return
@@ -179,8 +182,13 @@ class boot_splash(tk.Toplevel):
         try:
             directory = os.listdir(window.default_path)
         except OSError:
-            tkMessageBox.showerror("Error", "Error accessing directory set in settings. Please check your settings.")
-            directory = []
+            tkMessageBox.showerror("Error", "The CombatLogs folder found in the settings file is not valid. Please "
+                                            "choose another folder.")
+            folder = tkFileDialog.askdirectory(title="CombatLogs folder")
+            variables.settings_obj.write_settings_dict({('parsing', 'cl_path'): folder})
+            variables.settings_obj.read_set()
+            os.chdir(variables.settings_obj.cl_path)
+            directory = os.listdir(os.getcwd())
         files = []
         for file in directory:
             if file.endswith(".txt"):


### PR DESCRIPTION
This solution to #53 will majorly increase the user experience when first starting the GSF Parser if the default folder does not exist. This makes the GSF Parser much easier to use, as you don't have to figure out that you have to restart the GSF Parser after getting this error anymore.