### PR TITLE
Merge ui_testing into development to add UI unittests for #46

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,7 @@ test_script:
   - "cp %PYTHON%\\Lib\\lib-tk\\Dialog.pyc dist/main/Dialog.pyc"
   - "cp %PYTHON%\\Lib\\lib-tk\\tkColorChooser.py dist/main/tkColorChooser.py"
   - "cp %PYTHON%\\Lib\\site-packages\\configparser.pyc dist/main/ConfigParser.pyc"
+  - "cp assets dist/main/assets"
   - "cp LICENSE dist/main/LICENSE.txt"
   - "cp README.md dist/main/README.txt"
   - "7z a C:\\projects\\gsf-parser\\GSF_Parser_AppVeyor.zip dist/main/*"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,6 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python27-x64"
-os: unstable
 install:
   - "%PYTHON%\\python.exe -m pip install matplotlib numpy opencv-python pillow mock pyinstaller configparser"
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python27-x64"
+os: unstable
 install:
   - "%PYTHON%\\python.exe -m pip install matplotlib numpy opencv-python pillow mock pyinstaller configparser"
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ test_script:
   - "cp %PYTHON%\\Lib\\lib-tk\\Dialog.pyc dist/main/Dialog.pyc"
   - "cp %PYTHON%\\Lib\\lib-tk\\tkColorChooser.py dist/main/tkColorChooser.py"
   - "cp %PYTHON%\\Lib\\site-packages\\configparser.pyc dist/main/ConfigParser.pyc"
-  - "cp assets dist/main/assets"
+  - "cp -R assets dist/main/assets"
   - "cp LICENSE dist/main/LICENSE.txt"
   - "cp README.md dist/main/README.txt"
   - "7z a C:\\projects\\gsf-parser\\GSF_Parser_AppVeyor.zip dist/main/*"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,5 @@
+init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 environment:
   matrix:
     - PYTHON: "C:\\Python27"

--- a/testing.py
+++ b/testing.py
@@ -11,6 +11,8 @@ import os
 from PIL import Image
 import mock
 import sys
+import gui
+import Tkinter as tk
 
 
 class TestParseFunctions(unittest.TestCase):
@@ -110,8 +112,62 @@ class TestParseFunctions(unittest.TestCase):
                                            "20477000009322": 0})
 
 
+if sys.platform == "win32":
+    class TestUI(unittest.TestCase):
+        def setUp(self):
+            self.window = gui.main_window()
+
+        def tearDown(self):
+            self.window.destroy()
+
+        def test_instances(self):
+            self.assertIsInstance(self.window, tk.Tk)
+            for item in self.window.children.values():
+                self.assertIsInstance(item, tk.Widget)
+
+        def test_main_window(self):
+            self.window.update()
+
+        def test_notebook(self):
+            self.window.notebook.select(self.window.file_tab_frame)
+            self.window.update()
+            self.window.notebook.select(self.window.graphs_frame)
+            self.window.update()
+            self.window.notebook.select(self.window.realtime_tab_frame)
+            self.window.update()
+            self.window.notebook.select(self.window.share_tab_frame)
+            self.window.update()
+            self.window.notebook.select(self.window.resources_frame)
+            self.window.update()
+            self.window.notebook.select(self.window.settings_tab_frame)
+            self.window.update()
+
+        def test_file_adding(self):
+            self.window.file_select_frame.refresh_button.invoke()
+            self.window.update()
+            self.assertEqual(self.window.file_select_frame.file_box.get(0), "All CombatLogs")
+
+        def test_custom_color_toplevel(self):
+            self.window.settings_frame.event_scheme_custom_button.invoke()
+            self.window.update()
+            self.assertIsInstance(self.window.settings_frame.color_toplevel, tk.Toplevel)
+            self.window.update()
+            self.window.settings_frame.color_toplevel.destroy()
+
+        def test_realtime_parsing_button(self):
+            self.window.update()
+            self.window.update()
+            self.window.realtime_frame.start_parsing_button.invoke()
+            self.window.update()
+            self.assertTrue(self.window.realtime_frame.stalker_obj.is_alive())
+            self.window.realtime_frame.start_parsing_button.invoke()
+            self.assertFalse(self.window.realtime_frame.stalker_obj.is_alive())
+            self.window.update()
+
+
 class TestVision(unittest.TestCase):
     def test_get_pointer_position(self):
+        os.chdir(os.path.realpath(os.path.dirname(__file__)))
         example_image = Image.open(os.getcwd() + "/assets/vision/testing.png")
         if sys.platform == "win32":
             with mock.patch('PIL.ImageGrab.grab', return_value=example_image):

--- a/testing.py
+++ b/testing.py
@@ -12,7 +12,6 @@ from PIL import Image
 import mock
 import sys
 import gui
-print "Importing Tkinter"
 import Tkinter as tk
 
 
@@ -114,9 +113,6 @@ class TestParseFunctions(unittest.TestCase):
 
 
 if sys.platform == "win32":
-    print "Creating TestUI class"
-
-
     class TestUI(unittest.TestCase):
         def setUp(self):
             self.window = gui.main_window()
@@ -194,6 +190,8 @@ def grab():
 
 if __name__ == "__main__":
     print "\n"
+    if sys.platform == "win32":
+        os.makedirs((os.path.expanduser("~") + "\\Documents\\Star Wars - The Old Republic\\CombatLogs").
+                    replace("\\", "/"))
     from parsing import parse, vision
-    print "Starting unittest"
     unittest.main()

--- a/testing.py
+++ b/testing.py
@@ -12,6 +12,7 @@ from PIL import Image
 import mock
 import sys
 import gui
+print "Importing Tkinter"
 import Tkinter as tk
 
 
@@ -113,6 +114,9 @@ class TestParseFunctions(unittest.TestCase):
 
 
 if sys.platform == "win32":
+    print "Creating TestUI class"
+
+
     class TestUI(unittest.TestCase):
         def setUp(self):
             self.window = gui.main_window()
@@ -191,4 +195,5 @@ def grab():
 if __name__ == "__main__":
     print "\n"
     from parsing import parse, vision
+    print "Starting unittest"
     unittest.main()

--- a/testing.py
+++ b/testing.py
@@ -147,6 +147,7 @@ if sys.platform == "win32":
             self.window.file_select_frame.refresh_button.invoke()
             self.window.update()
             self.assertEqual(self.window.file_select_frame.file_box.get(0), "All CombatLogs")
+            self.assertEqual(self.window.file_select_frame.file_box.get(1), "2017-02-26   12:00")
 
         def test_custom_color_toplevel(self):
             self.window.settings_frame.event_scheme_custom_button.invoke()
@@ -202,6 +203,10 @@ if __name__ == "__main__":
                         replace("\\", "/"))
         except OSError:
             pass
+        with open((os.path.expanduser("~") + "\\Documents\\Star Wars - The Old Republic\\CombatLogs\\").
+                        replace("\\", "/") + "combat_2017-02-26_12_00_00_000000.txt", "w") as target_log:
+            with open(os.getcwd() + "/CombatLog.txt", "r") as source_log:
+                target_log.writelines(source_log.readlines())
         tkMessageBox.showerror = messagebox
         tkMessageBox.showinfo = messagebox
     from parsing import parse, vision

--- a/testing.py
+++ b/testing.py
@@ -13,6 +13,7 @@ import mock
 import sys
 import gui
 import Tkinter as tk
+import tkMessageBox
 
 
 class TestParseFunctions(unittest.TestCase):
@@ -188,10 +189,20 @@ class TestVision(unittest.TestCase):
 def grab():
     return Image.open(os.getcwd() + "/assets/vision/testing.png")
 
+
+def messagebox(title, message):
+    pass
+
+
 if __name__ == "__main__":
     print "\n"
     if sys.platform == "win32":
-        os.makedirs((os.path.expanduser("~") + "\\Documents\\Star Wars - The Old Republic\\CombatLogs").
-                    replace("\\", "/"))
+        try:
+            os.makedirs((os.path.expanduser("~") + "\\Documents\\Star Wars - The Old Republic\\CombatLogs").
+                        replace("\\", "/"))
+        except OSError:
+            pass
+        tkMessageBox.showerror = messagebox
+        tkMessageBox.showinfo = messagebox
     from parsing import parse, vision
     unittest.main()


### PR DESCRIPTION
This branch contains commits that add unittests for the user interface to `testing.py` for issuse #46. More tests could still be added, but this is a good place to start. Also this branch contains commits to fix things with AppVeyor CI in order to allow running these tests every time a commit is pushed. These tests use, among others, the `invoke` function of `Button`s to call the callback manually. Because sometimes the does start and the gridding completes but the UI crashes when moving to the tab with a UI problem, the `select` function of the `ttk.Notebook` is also called for testing.