### PR TITLE
Add DPI scaling to all GSF Parser widgets

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -33,7 +33,6 @@ class main_window(tk.Tk):
     def __init__(self):
         # Initialize window
         tk.Tk.__init__(self)
-        self.protocol("WM_DELETE_WINDOW", self.on_close)
         dpi_value = self.winfo_fpixels('1i')
         self.tk.call('tk', 'scaling', '-displayof', '.', dpi_value / 72.0)
         self.finished = False

--- a/gui.py
+++ b/gui.py
@@ -33,6 +33,9 @@ class main_window(tk.Tk):
     def __init__(self):
         # Initialize window
         tk.Tk.__init__(self)
+        self.protocol("WM_DELETE_WINDOW", self.on_close)
+        dpi_value = self.winfo_fpixels('1i')
+        self.tk.call('tk', 'scaling', '-displayof', '.', dpi_value / 72.0)
         self.finished = False
         self.style = ttk.Style()
         self.set_icon()

--- a/parsing/stalking.py
+++ b/parsing/stalking.py
@@ -225,7 +225,7 @@ class LogStalker(threading.Thread):
         except IOError:
             tkMessageBox.showerror("Error",
                                    "The real-time parsing process encountered a known bug. Please restart the GSF Parser.")
-            variables.main_window.on_close()
+            variables.main_window.destroy()
         except EnvironmentError as err:
             if err.errno != errno.ENOENT:
                 raise


### PR DESCRIPTION
This code enables DPI scaling for the GSF Parser windows and all widgets with three simple lines of code. This was not requested, I simply stumbled over this code.