### PR TITLE
Merge pyinstaller into master for Windows 7 Tcl compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.ini
 *.db
 *.xml
+*.spec
 Release
 .idea
 __pycache__

--- a/main.py
+++ b/main.py
@@ -3,7 +3,15 @@
 # Thranta Squadron GSF CombatLog Parser, Copyright (C) 2016 by RedFantom, Daethyra and Sprigellania
 # All additions are under the copyright of their respective authors
 # For license see LICENSE
+from os.path import dirname, join, basename
 import sys
+try:
+    tcl_lib = join(sys._MEIPASS, "lib")
+    tcl_new_lib = join(dirname(dirname(tcl_lib)), basename(tcl_lib))
+    import shutil
+    shutil.copytree(src=tcl_lib, dst=tcl_new_lib)
+except AttributeError:
+    pass
 import tkMessageBox
 import gui
 


### PR DESCRIPTION
This branch contains code contributed by @dferrant that solves issue #17, providing a way to run the GSF Parser on Windows 7. The `.spec` file resides on my computer, but it can easily be recreated with the code snippet in #17.