### PR TITLE
Merge mouse into master to fix TclError with VerticalScrollFrame

### DIFF
--- a/widgets/verticalscrollframe.py
+++ b/widgets/verticalscrollframe.py
@@ -33,8 +33,7 @@ class VerticalScrollFrame(ttk.Frame):
         vscrollbar.config(command=canvas.yview)
 
         def mousewheel(event):
-            print("[DEBUG] Being scrolled")
-            canvas.yview_scroll(-1 * (event.delta / 100), "units")
+            canvas.yview_scroll(int(-1 * (event.delta / 100)), "units")
 
         canvas.bind("<MouseWheel>", mousewheel)
         canvas.xview_moveto(0)


### PR DESCRIPTION
Scrolling in a VerticalScrollFrame widget causes TclErrors. These errors do not affect functionality, but it's better to fix them anyway. This branch contains the commit to do so, and should be merged.