### PR TITLE
Merge seven into master to simplify building process

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,27 +5,33 @@
 # For license see LICENSE
 
 from os.path import dirname, join, basename
-
-try:
-    import sys
-    import shutil
-    tcl_lib = join(sys._MEIPASS, "lib")
-    tcl_new_lib = join(dirname(dirname(tcl_lib)), basename(tcl_lib))
-    shutil.copytree(src=tcl_lib, dst=tcl_new_lib)
-except AttributeError:
-    pass
-except FileNotFoundError:
-    pass
-except FileExistsError:
-    pass
-
-import gui
+import sys
+import shutil
+import platform
 
 
 def new_window():
+    import gui
     main_window = gui.MainWindow()
     main_window.mainloop()
 
 
-if __name__ == "__main__":
+def setup_tkinter():
+    if "Windows-7" not in platform.platform():
+        return
+    try:
+        tcl_lib = join(sys._MEIPASS, "lib")
+        tcl_new_lib = join(dirname(dirname(tcl_lib)), basename(tcl_lib))
+        shutil.copytree(src=tcl_lib, dst=tcl_new_lib)
+    except AttributeError:
+        pass
+    except FileNotFoundError:
+        pass
+    except FileExistsError:
+        pass
+    return
+
+
+if __name__ == '__main__':
+    setup_tkinter()
     new_window()

--- a/main.py
+++ b/main.py
@@ -3,18 +3,22 @@
 # Thranta Squadron GSF CombatLog Parser, Copyright (C) 2016 by RedFantom, Daethyra and Sprigellania
 # All additions are under the copyright of their respective authors
 # For license see LICENSE
-"""
+
 from os.path import dirname, join, basename
 
 try:
+    import sys
+    import shutil
     tcl_lib = join(sys._MEIPASS, "lib")
     tcl_new_lib = join(dirname(dirname(tcl_lib)), basename(tcl_lib))
-    import shutil
-
     shutil.copytree(src=tcl_lib, dst=tcl_new_lib)
 except AttributeError:
     pass
-"""
+except FileNotFoundError:
+    pass
+except FileExistsError:
+    pass
+
 import gui
 
 


### PR DESCRIPTION
This code detects Windows 7 and activates the right fix for the pyinstaller issue accordingly making it possible to distribute only a single GSF Parser binary instead of two.