### PR TITLE
Merge database_explorer into master to add DatabaseExplorer tool

### DIFF
--- a/frames/toolsframe.py
+++ b/frames/toolsframe.py
@@ -18,6 +18,7 @@ from widgets import verticalscrollframe
 from parsing.guiparsing import GSFInterface, get_gui_profiles
 from tools.utilities import get_assets_directory
 from toplevels.importer import SettingsImporter
+from tools.database_explorer import DatabaseExplorer
 
 
 class ToolsFrame(ttk.Frame):
@@ -105,13 +106,25 @@ class ToolsFrame(ttk.Frame):
         self.importer_button = ttk.Button(self.interior_frame.interior, text="Start importer",
                                           command=self.start_importer)
         self.separator_six = ttk.Separator(self.interior_frame.interior, orient=tk.HORIZONTAL)
+        self.database_explorer_heading_label = ttk.Label(self.interior_frame.interior, text="Database Explorer",
+                                                         font=("Calibri", 12))
+        self.database_explorer_description_label = ttk.Label(self.interior_frame.interior,
+                                                             text="A small utility useful in debugging the GSF Parser. "
+                                                                  "Provides all the data of Screen Parsing in a nice "
+                                                                  "Treeview to make browsing through the data "
+                                                                  "convenient and fast.",
+                                                             justify=tk.LEFT, wraplength=780)
+        self.database_explorer_button = ttk.Button(self.interior_frame.interior, text="Open Database Explorer",
+                                                   command=self.open_database_explorer)
+        self.separator_seven = ttk.Separator(self.interior_frame.interior, orient=tk.HORIZONTAL)
 
     def start_simulator(self):
         self.simulator_thread = threading.Thread(target=lambda file_name=self.simulator_file,
-                                                               dir=variables.settings_obj["parsing"]["cl_path"]: simulator.simulate(
-                                                                                                    file_name,
-                                                                                                    output_directory=dir
-                                                                                                   ))
+                                                               dir=variables.settings_obj["parsing"][
+                                                                   "cl_path"]: simulator.simulate(
+            file_name,
+            output_directory=dir
+        ))
         self.simulator_thread.start()
 
     @staticmethod
@@ -185,6 +198,9 @@ class ToolsFrame(ttk.Frame):
         self.cartelfix_button.config(text="Close CartelFix")
         self.cartelfix.start_listener()
 
+    def open_database_explorer(self):
+        DatabaseExplorer(variables.main_window)
+
     @staticmethod
     def open_old_parser():
         variables.main_window.destroy()
@@ -220,3 +236,7 @@ class ToolsFrame(ttk.Frame):
         self.importer_description_label.grid(row=20, column=0, columnspan=10, sticky="w")
         self.importer_button.grid(row=21, column=0, sticky="we", columnspan=2)
         self.separator_six.grid(row=22, column=0, columnspan=10, sticky="we", pady=5)
+        self.database_explorer_heading_label.grid(row=23, column=0, columnspan=10, sticky="w")
+        self.database_explorer_description_label.grid(row=24, column=0, columnspan=10, sticky="w")
+        self.database_explorer_button.grid(row=25, column=0, columnspan=2, sticky="nswe")
+        self.separator_seven.grid(row=26, column=0, columnspan=10, sticky="we", pady=5)

--- a/tools/database_explorer.py
+++ b/tools/database_explorer.py
@@ -1,0 +1,70 @@
+# Written by RedFantom, Wing Commander of Thranta Squadron,
+# Daethyra, Squadron Leader of Thranta Squadron and Sprigellania, Ace of Thranta Squadron
+# Thranta Squadron GSF CombatLog Parser, Copyright (C) 2016 by RedFantom, Daethyra and Sprigellania
+# All additions are under the copyright of their respective authors
+# For license see LICENSE
+import tkinter as tk
+from tkinter import ttk
+# Own modules
+from parsing.screen import FileHandler
+
+
+class DatabaseExplorer(tk.Toplevel):
+    def __init__(self, *args, **kwargs):
+        tk.Toplevel.__init__(self, *args, **kwargs)
+        self.wm_title("GSF Parser: Database Explorer")
+        self.data = FileHandler.get_data_dictionary()
+        self.tree = ttk.Treeview(self, height=15)
+        self.tree.config(show=("headings", "tree"), columns=())
+        self.tree.heading("#0", text="List")
+        self.tree.column("#0", width=400)
+        self.scroll = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.tree.yview)
+        self.tree.config(yscrollcommand=self.scroll.set)
+        self.refresh_button = ttk.Button(self, text="Refresh", command=self.update_tree)
+        self.bind("<F5>", self.update_tree)
+        self.update_tree()
+        self.grid_widgets()
+
+    def grid_widgets(self):
+        self.tree.grid(row=1, column=1, sticky="nswe", padx=5, pady=5)
+        self.scroll.grid(row=1, column=2, sticky="ns", padx=(0, 5), pady=5)
+        self.refresh_button.grid(row=2, column=1, columnspan=2, sticky="nswe", padx=5, pady=(0, 5))
+
+    def update_tree(self, *args):
+        self.tree.delete(*self.tree.get_children(""))
+        self.data = FileHandler.get_data_dictionary()
+        for file, data_file in self.data.items():
+            if file == "" or file is None:
+                continue
+            self.tree.insert("", tk.END, iid=file, text=file)
+            for match, data_match in data_file.items():
+                if match is None:
+                    continue
+                match_string = match.strftime("%H:%M:%S")
+                self.tree.insert(file, tk.END, iid="{}+{}".format(file, match_string), text=match_string)
+                for spawn, data_spawn in data_match.items():
+                    if spawn is None:
+                        continue
+                    spawn_string = spawn.strftime("%H:%M:%S")
+                    self.tree.insert("{}+{}".format(file, match_string), tk.END,
+                                     iid="{}+{}+{}".format(file, match_string, spawn_string),
+                                     text=spawn_string)
+                    for data_type, special_data in data_spawn.items():
+                        if data_type is None:
+                            continue
+                        self.tree.insert("{}+{}+{}".format(file, match_string, spawn_string), tk.END,
+                                         iid="{}+{}+{}+{}".format(file, match_string, spawn_string, data_type),
+                                         text=data_type)
+                        for moment in sorted(special_data.keys()):
+                            if moment is None:
+                                continue
+                            data_collected = special_data[moment]
+                            parent = self.tree.insert("{}+{}+{}+{}".format(file, match_string, spawn_string, data_type),
+                                                      tk.END,
+                                                      text=moment.strftime("%H:%S"))
+                            self.tree.insert(parent, tk.END, text=str(data_collected))
+        return
+
+
+if __name__ == '__main__':
+    DatabaseExplorer().mainloop()


### PR DESCRIPTION
This basic tool makes it possible to move through the Screen Parsing database manually, extracting data from it by hand, or making debugging a lot easier. Added because it might have some use for the real GSF number crunchers, as not everything is in `FileHandler` *yet*.